### PR TITLE
docs: add ports used for services in docker-setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 docker/logs/apache2/*
 docker/logs/mysql/*
-docker/container-data
+docker/container-data/*

--- a/README.md
+++ b/README.md
@@ -52,4 +52,6 @@ Run the executable script file `run-docker.sh` in the repo home with any of the 
 ./run-docker.sh start
 ```
 
+The application starts at `90` and phpmyadmin at `8081` instead of the usual ports, to avoid chances of possible conflicts with any local services. 
+
 Note: You can also stop the containers/exit from the terminal window by pressing <kbd>CTRL</kbd> + <kbd>C</kbd>


### PR DESCRIPTION
Adds the ports used for running the application and PHPMyAdmin in the readme file.